### PR TITLE
docs: fix Codex plugin install steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,15 +173,9 @@ Use this when you want to work inside this repository and keep the plugin local 
 1. Open this repository in Codex.
 2. Make sure [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) exists.
 3. If Codex was already running, restart it so the repo marketplace and project-scoped agents are reloaded.
-4. Open the plugin directory:
-
-```bash
-codex
-/plugins
-```
-
-5. In the marketplace picker, open `llmdoc Local Plugins`.
-6. Install the plugin `llmdoc`.
+4. In Codex, run `/plugins`.
+5. Find `llmdoc` in the plugin list, select it to open the detail page.
+6. Install the plugin.
 7. Start a new thread in this repository and either:
    - ask Codex to load the `llmdoc` skill first for normal work
    - choose `llmdoc-init` when you want the `/llmdoc:init` workflow
@@ -228,9 +222,9 @@ cp -R /absolute/path/to/llmdoc ~/.codex/plugins/llmdoc
 ```
 
 3. Restart Codex.
-4. Open the plugin directory with `codex` and `/plugins`.
-5. In the marketplace picker, open `My Local Plugins`.
-6. Install the plugin `llmdoc`.
+4. In Codex, run `/plugins`.
+5. Find `llmdoc` in the plugin list, select it to open the detail page.
+6. Install the plugin.
 7. Start a new thread in any repository and either:
    - ask Codex to load the `llmdoc` skill first for normal work
    - choose `llmdoc-init` when you want the `/llmdoc:init` workflow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,15 +173,9 @@ codex
 1. 用 Codex 打开这个仓库
 2. 确认 [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) 存在
 3. 如果 Codex 已经在运行，先重启一次，让 repo marketplace 和 project-scoped agents 重新加载
-4. 打开插件列表：
-
-```bash
-codex
-/plugins
-```
-
-5. 在 marketplace 列表里打开 `llmdoc Local Plugins`
-6. 安装插件 `llmdoc`
+4. 在 Codex 中执行 `/plugins`
+5. 在插件列表中找到 `llmdoc`，选中进入详情页
+6. 安装插件
 7. 在这个仓库里新开一个对话，然后按你的目标选择入口：
    - 正常工作时，让 Codex 先加载 `llmdoc` skill
    - 要执行 `/llmdoc:init` 等价流程时，选择 `llmdoc-init`
@@ -228,9 +222,9 @@ cp -R /absolute/path/to/llmdoc ~/.codex/plugins/llmdoc
 ```
 
 3. 重启 Codex
-4. 用 `codex` 打开 CLI，然后执行 `/plugins`
-5. 在 marketplace 列表里打开 `My Local Plugins`
-6. 安装插件 `llmdoc`
+4. 在 Codex 中执行 `/plugins`
+5. 在插件列表中找到 `llmdoc`，选中进入详情页
+6. 安装插件
 7. 在任意仓库里新开一个对话，然后按你的目标选择入口：
    - 正常工作时，让 Codex 先加载 `llmdoc` skill
    - 要执行 `/llmdoc:init` 等价流程时，选择 `llmdoc-init`


### PR DESCRIPTION
Replace incorrect marketplace picker flow with the actual install flow: restart Codex, run /plugins, find llmdoc, select to open detail page, then install. Applied to both Option 1 and Option 2 in English and Chinese READMEs.