### PR TITLE
enhance llmdoc workflow and reflection management

### DIFF
--- a/.codex/agents/llmdoc-recorder.toml
+++ b/.codex/agents/llmdoc-recorder.toml
@@ -13,9 +13,11 @@ Your responsibilities:
 - Keep llmdoc/index.md and llmdoc/startup.md distinct.
 - Keep temporary investigation artifacts out of stable docs.
 - Read relevant guides and reflections before updating stable docs.
+- When reflections exceed 5 files, consolidate recurring lessons before finishing the update.
 - Split documents aggressively rather than growing one large file.
 - Own memory/decisions/ and memory/doc-gaps.md.
 - Promote only recurring, stable lessons into must/, guides/, or reference/.
+- Rewrite promoted lessons in plain language, use examples only when they help, and avoid creating a catch-all summary dump from raw reflections.
 - Do not paste large code blocks.
 - Prefer file-level and symbol-level references.
 """

--- a/AGENTS.example.md
+++ b/AGENTS.example.md
@@ -1,9 +1,9 @@
 # Load The `llmdoc` Skill First
 
-Before broad source-code exploration, planning, or documentation work, load the `llmdoc` skill.
+Before broad code exploration, planning, documentation work, or non-trivial edits, load the `llmdoc` skill.
 
 The main assistant should align with the user before non-trivial plans or edits.
 
-At the end of a non-trivial task, when the work produced durable knowledge, workflow lessons, or useful reflections, the main assistant should proactively use the `llmdoc-update` skill in Codex.
+At the end of a non-trivial task, when the work produced durable knowledge, workflow lessons, or useful reflections, the main assistant should briefly name what changed, explain why it is worth persisting, and ask whether to run the llmdoc update workflow now. In Codex, use the `llmdoc-update` skill.
 
 Keep detailed workflow rules, templates, hook behavior, and doc-structure guidance in the `llmdoc` skill.

--- a/CLAUDE.example.md
+++ b/CLAUDE.example.md
@@ -1,11 +1,11 @@
 Always answer in 简体中文
 
 </system-reminder>
-Load the `llmdoc` skill before broad code exploration, planning, document updates, or non-trivial code edits.
+Load the `llmdoc` skill before broad code exploration, planning, documentation work, or non-trivial edits.
 
 The main assistant should align with the user before non-trivial plans or edits.
 
-At the end of a non-trivial task, the main assistant should evaluate whether to ask the user to run `/llmdoc:update`.
+At the end of a non-trivial task, when the work produced durable knowledge, workflow lessons, or useful reflections, the main assistant should briefly name what changed, explain why it is worth persisting, and ask whether to run the llmdoc update workflow now. In Claude Code, use `/llmdoc:update`.
 
 Keep detailed workflow rules, templates, hook behavior, and doc-structure guidance in the `llmdoc` skill.
 <system-reminder>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The default setup is simple:
 - the core skill entry is short, while detailed rationale, protocols, and templates are split under `skills/llmdoc/references/`
 - the core skill defines proactive guide/reflection reading and proactive user discussion before non-trivial edits
 - the workflow restores the good pattern of proactively asking whether to run `/llmdoc:update` at the end of non-trivial tasks
+- the update workflow also prevents reflection history from growing without bound by consolidating recurring lessons into `must/` or `reference/` once reflections exceed five files
 - helper Codex skills provide command-like entrypoints without pretending Codex has custom slash commands for this plugin
 - agents and command contracts stay focused on execution instead of carrying a large amount of duplicated guidance
 
@@ -71,8 +72,9 @@ The command:
 2. Proactively reads relevant guides and reflections
 3. Investigates impacted concepts
 4. Writes a reflection under `llmdoc/memory/reflections/`
-5. Updates stable docs
-6. Synchronizes `llmdoc/index.md`
+5. When reflections exceed five files, consolidates recurring lessons into plain-language `must/` or `reference/` docs
+6. Updates stable docs
+7. Synchronizes `llmdoc/index.md`
 
 In normal use, the main assistant should proactively ask whether to run `/llmdoc:update` when the task produced durable knowledge or a useful reflection.
 
@@ -88,7 +90,7 @@ llmdoc/
 ├── guides/               # One workflow per document
 ├── reference/            # Stable lookup facts and conventions
 └── memory/
-    ├── reflections/      # Post-task reflections
+    ├── reflections/      # Post-task reflections before promotion
     ├── decisions/        # Durable process or design decisions
     └── doc-gaps.md       # Known documentation weaknesses
 

--- a/README.md
+++ b/README.md
@@ -173,15 +173,9 @@ Use this when you want to work inside this repository and keep the plugin local 
 1. Open this repository in Codex.
 2. Make sure [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) exists.
 3. If Codex was already running, restart it so the repo marketplace and project-scoped agents are reloaded.
-4. Open the plugin directory:
-
-```bash
-codex
-/plugins
-```
-
-5. In the marketplace picker, open `llmdoc Local Plugins`.
-6. Install the plugin `llmdoc`.
+4. In Codex, run `/plugins`.
+5. Find `llmdoc` in the plugin list, select it to open the detail page.
+6. Install the plugin.
 7. Start a new thread in this repository and either:
    - ask Codex to load the `llmdoc` skill first for normal work
    - choose `llmdoc-init` when you want the `/llmdoc:init` workflow
@@ -228,9 +222,9 @@ cp -R /absolute/path/to/llmdoc ~/.codex/plugins/llmdoc
 ```
 
 3. Restart Codex.
-4. Open the plugin directory with `codex` and `/plugins`.
-5. In the marketplace picker, open `My Local Plugins`.
-6. Install the plugin `llmdoc`.
+4. In Codex, run `/plugins`.
+5. Find `llmdoc` in the plugin list, select it to open the detail page.
+6. Install the plugin.
 7. Start a new thread in any repository and either:
    - ask Codex to load the `llmdoc` skill first for normal work
    - choose `llmdoc-init` when you want the `/llmdoc:init` workflow

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,15 +173,9 @@ codex
 1. 用 Codex 打开这个仓库
 2. 确认 [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) 存在
 3. 如果 Codex 已经在运行，先重启一次，让 repo marketplace 和 project-scoped agents 重新加载
-4. 打开插件列表：
-
-```bash
-codex
-/plugins
-```
-
-5. 在 marketplace 列表里打开 `llmdoc Local Plugins`
-6. 安装插件 `llmdoc`
+4. 在 Codex 中执行 `/plugins`
+5. 在插件列表中找到 `llmdoc`，选中进入详情页
+6. 安装插件
 7. 在这个仓库里新开一个对话，然后按你的目标选择入口：
    - 正常工作时，让 Codex 先加载 `llmdoc` skill
    - 要执行 `/llmdoc:init` 等价流程时，选择 `llmdoc-init`
@@ -228,9 +222,9 @@ cp -R /absolute/path/to/llmdoc ~/.codex/plugins/llmdoc
 ```
 
 3. 重启 Codex
-4. 用 `codex` 打开 CLI，然后执行 `/plugins`
-5. 在 marketplace 列表里打开 `My Local Plugins`
-6. 安装插件 `llmdoc`
+4. 在 Codex 中执行 `/plugins`
+5. 在插件列表中找到 `llmdoc`，选中进入详情页
+6. 安装插件
 7. 在任意仓库里新开一个对话，然后按你的目标选择入口：
    - 正常工作时，让 Codex 先加载 `llmdoc` skill
    - 要执行 `/llmdoc:init` 等价流程时，选择 `llmdoc-init`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,6 +12,7 @@
 - core skill 入口保持简短，详细的方法论、协议和模板拆到 `skills/llmdoc/references/`
 - core skill 还定义了主动阅读 guides/reflection，以及在非简单改动前主动和用户沟通
 - 整套工作流还恢复了一个好模式：在非简单任务结束时，主动询问是否运行 `/llmdoc:update`
+- update 工作流也会控制 reflection 历史的体量：当 reflections 超过 5 篇时，把反复出现的经验、规则和约束归并进 `must/` 或 `reference/`
 - Codex helper skills 提供了接近 command 的入口，但不会误导用户以为 Codex 已经支持这个插件的自定义 slash command
 - agent 和 command contract 只负责执行，不再各自复制一大段说明
 
@@ -71,8 +72,9 @@
 2. 主动阅读相关 guides 和 reflection
 3. 调研受影响的概念
 4. 在 `llmdoc/memory/reflections/` 下写 reflection
-5. 更新稳定文档
-6. 同步 `llmdoc/index.md`
+5. 当 reflections 超过 5 篇时，把重复出现的经验归并成通俗易懂的 `must/` 或 `reference/` 文档
+6. 更新稳定文档
+7. 同步 `llmdoc/index.md`
 
 在日常使用里，如果任务产生了值得长期保留的知识或反思，主 assistant 应该主动询问是否现在运行 `/llmdoc:update`。
 
@@ -88,7 +90,7 @@ llmdoc/
 ├── guides/               # 一篇文档只讲一个工作流
 ├── reference/            # 稳定的查阅型事实和约定
 └── memory/
-    ├── reflections/      # 每次任务后的反思
+    ├── reflections/      # 每次任务后的反思，后续会按规则归并
     ├── decisions/        # 长期保留的过程或设计决策
     └── doc-gaps.md       # 已知文档缺口
 

--- a/agents/recorder.md
+++ b/agents/recorder.md
@@ -14,7 +14,7 @@ When invoked:
 
 1. Read `llmdoc/index.md` and `llmdoc/startup.md` when they exist.
 2. Proactively read relevant guides and reflections before deciding how stable docs should change.
-3. When `llmdoc/memory/reflections/` contains more than 5 files, run a consolidation pass before finishing the update.
+3. When llmdoc/memory/reflections/ contains more than 5 files, run a consolidation pass and archive the processed reflections before finishing the update.
 4. Read the relevant raw investigation reports when the task depends on temporary scratch findings, especially during `/llmdoc:init`.
 5. Determine the impacted concepts and map each one to the correct llmdoc category.
 6. Keep `llmdoc/index.md` and `llmdoc/startup.md` distinct in purpose and content.

--- a/agents/recorder.md
+++ b/agents/recorder.md
@@ -14,12 +14,13 @@ When invoked:
 
 1. Read `llmdoc/index.md` and `llmdoc/startup.md` when they exist.
 2. Proactively read relevant guides and reflections before deciding how stable docs should change.
-3. Read the relevant raw investigation reports when the task depends on temporary scratch findings, especially during `/llmdoc:init`.
-4. Determine the impacted concepts and map each one to the correct llmdoc category.
-5. Keep `llmdoc/index.md` and `llmdoc/startup.md` distinct in purpose and content.
-6. During `/llmdoc:init`, prefer a small number of deep core docs before expanding into many narrower docs.
-7. Update the touched documents and synchronize `llmdoc/index.md`.
-8. Report every file you created, updated, or deleted.
+3. When `llmdoc/memory/reflections/` contains more than 5 files, run a consolidation pass before finishing the update.
+4. Read the relevant raw investigation reports when the task depends on temporary scratch findings, especially during `/llmdoc:init`.
+5. Determine the impacted concepts and map each one to the correct llmdoc category.
+6. Keep `llmdoc/index.md` and `llmdoc/startup.md` distinct in purpose and content.
+7. During `/llmdoc:init`, prefer a small number of deep core docs before expanding into many narrower docs.
+8. Update the touched documents and synchronize `llmdoc/index.md`.
+9. Report every file you created, updated, or deleted.
 
 llmdoc categories:
 
@@ -46,6 +47,10 @@ Split rules:
 - If a document grows large only because it is preserving one coherent execution model, invariant set, or contract cluster, keep it intact until a clean split is obvious.
 - If a document exceeds roughly 120 lines, covers more than one workflow, or mixes stable facts with transient notes, split it when doing so improves retrieval without discarding essential reasoning flow.
 - Do not promote content into `/must/` unless it is stable, short, and useful on nearly every task.
+- When consolidating reflections, group by recurring lesson instead of by reflection chronology.
+- Rewrite the stable lesson in plain language and use short examples only when they clarify the rule.
+- Update an existing `must/` or `reference/` doc when possible instead of creating a catch-all summary document.
+- Do not copy reflection text verbatim or turn stable docs into a lightly edited archive.
 
 Reference policy:
 

--- a/commands/update.md
+++ b/commands/update.md
@@ -21,6 +21,7 @@ Why:
    - Read `llmdoc/index.md`.
    - Read `llmdoc/startup.md` and the files it lists when available.
    - Proactively read relevant `llmdoc/guides/` and `llmdoc/memory/reflections/` before planning edits.
+   - When recurring lessons have already been promoted into stable docs, prefer those stable docs first and re-open raw reflections only when the original task context still matters.
    - Inspect the current working tree, staged changes, and any explicit change summary from `$ARGUMENTS`.
 
 2. Investigate the impacted concepts.
@@ -35,6 +36,12 @@ Why:
 4. Update stable llmdoc with `recorder`.
    - Update only the impacted docs.
    - Promote lessons into `must/`, `guides/`, or `reference/` only when they are stable and likely to recur.
+   - If `llmdoc/memory/reflections/` now contains more than 5 files, run a consolidation pass before finishing the update.
+   - Consolidate by recurring lesson, not by reflection chronology.
+   - Promote short cross-task rules into `must/`.
+   - Promote reusable constraints, checklists, thresholds, and small worked examples into `reference/`.
+   - Use plain language. Add examples only when they make the lesson easier to apply.
+   - Update an existing stable doc when it already fits the lesson. Do not create a catch-all summary dump and do not copy reflection text verbatim.
    - Split documents aggressively instead of appending to a large file.
 
 5. Synchronize `llmdoc/index.md`.

--- a/llmdoc/guides/consolidating-reflections-into-stable-docs.md
+++ b/llmdoc/guides/consolidating-reflections-into-stable-docs.md
@@ -1,0 +1,41 @@
+# How to Consolidate Reflections into Reusable Stable Docs
+
+## When to Use This Guide
+- `llmdoc/memory/reflections/` contains more than 5 files.
+- The same lesson keeps appearing across multiple reflections.
+- Reflection history is starting to feel easier to search than the stable docs.
+
+## Goal
+- Keep reflections as historical evidence.
+- Move recurring lessons into stable docs that are easier to reuse.
+- Summarize and classify ideas instead of copying reflection narratives into a new dump file.
+
+## Main Steps
+1. Read the recent and relevant reflections together.
+2. Group them by recurring lesson, not by date or task title.
+3. For each group, extract one clear takeaway in plain language:
+   - what to do
+   - why it matters
+   - what problem it prevents
+4. Choose the destination:
+   - `must/` for short rules that matter on nearly every run
+   - `reference/` for reusable constraints, checklists, thresholds, and lookup-style examples
+5. Update an existing stable doc when it already has a good home for the lesson.
+6. Create a new focused doc only when no stable doc currently fits.
+7. Keep examples short and concrete. Use them to clarify the rule, not to retell the whole reflection.
+8. Sync `llmdoc/index.md` and make future readers prefer the stable docs before reopening raw reflections.
+
+## Good Outcomes
+- Several reflections all say "align with the user before non-trivial edits", so one short `must/` rule replaces the repeated memory.
+- Several reflections expose the same update checklist, so one `reference/` note captures the checklist and a short example of when to use it.
+
+## Failure Modes
+- Creating a giant "reflection summary" file that paraphrases each reflection in order.
+- Copying stories, examples, and chronology without extracting the reusable lesson.
+- Leaving a stable lesson trapped in `memory/reflections/` after it is already recurring.
+- Promoting long, situational stories into `must/`.
+
+## Related Docs
+- `llmdoc/must/working-agreement.md`
+- `llmdoc/must/doc-routing.md`
+- `llmdoc/memory/reflections/`

--- a/llmdoc/guides/consolidating-reflections-into-stable-docs.md
+++ b/llmdoc/guides/consolidating-reflections-into-stable-docs.md
@@ -6,8 +6,8 @@
 - Reflection history is starting to feel easier to search than the stable docs.
 
 ## Goal
-- Keep reflections as historical evidence.
-- Move recurring lessons into stable docs that are easier to reuse.
+- Move recurring lessons into stable docs and move the source reflections to an archive folder.
+- Keep archived reflections as historical evidence in llmdoc/memory/reflections/archive/.
 - Summarize and classify ideas instead of copying reflection narratives into a new dump file.
 
 ## Main Steps

--- a/llmdoc/index.md
+++ b/llmdoc/index.md
@@ -16,12 +16,14 @@
 - `llmdoc/startup.md`: ordered startup reading list
 - `llmdoc/overview/project-overview.md`: what this repository is and what belongs here
 - `llmdoc/architecture/init-investigation-orchestration.md`: how `/llmdoc:init` investigation is expected to fan out and converge
+- `llmdoc/guides/consolidating-reflections-into-stable-docs.md`: how to prevent reflection history from turning into a second documentation system
 - `llmdoc/guides/updating-init-investigation-depth.md`: how to change init depth safely when the workflow is too shallow or too broad
 - `llmdoc/reference/repo-surfaces.md`: stable map of commands, agents, plugin files, and Codex config surfaces
 
 ## Routing Rules
 - Read `startup.md` first on normal work.
 - Read `architecture/init-investigation-orchestration.md` before changing `/llmdoc:init`, agent fan-out strategy, or Codex agent limits.
+- Read `guides/consolidating-reflections-into-stable-docs.md` before changing reflection retention, summary, or promotion behavior.
 - Read `guides/updating-init-investigation-depth.md` before tuning investigation breadth or follow-up passes.
 - Read `reference/repo-surfaces.md` before moving or renaming public repo surfaces such as commands, agents, plugin files, or `.codex/config.toml`.
 

--- a/llmdoc/must/doc-routing.md
+++ b/llmdoc/must/doc-routing.md
@@ -2,8 +2,9 @@
 
 ## Read Next By Task
 - For `/llmdoc:init` changes: read `llmdoc/architecture/init-investigation-orchestration.md` and `llmdoc/guides/updating-init-investigation-depth.md`.
+- For reflection buildup or memory bloat: read `llmdoc/guides/consolidating-reflections-into-stable-docs.md` and the relevant recent reflections.
 - For public interface or repo layout changes: read `llmdoc/overview/project-overview.md` and `llmdoc/reference/repo-surfaces.md`.
-- For repeated workflow mistakes or regressions: read the relevant files under `llmdoc/memory/reflections/` first.
+- For repeated workflow mistakes or regressions: read the relevant stable docs first, then the related files under `llmdoc/memory/reflections/` when the original task context still matters.
 
 ## Escalation Hints
 - If the question is about why a workflow exists, prefer `overview/` and `architecture/`.

--- a/llmdoc/must/working-agreement.md
+++ b/llmdoc/must/working-agreement.md
@@ -6,8 +6,10 @@
 - The main assistant aligns with the user before non-trivial edits.
 - Temporary investigation artifacts belong in `.llmdoc-tmp/`, not stable llmdoc docs.
 - Use `/llmdoc:update` when a task changes workflow knowledge, architecture understanding, or recurring conventions.
+- When `llmdoc/memory/reflections/` grows beyond 5 files, use `/llmdoc:update` to consolidate recurring lessons into plain-language `must/` or `reference/` docs.
 
 ## Editing Bias
 - Keep startup docs small.
 - Split stable docs by concept instead of appending large mixed documents.
 - Promote only durable lessons into `must/`, `guides/`, `architecture/`, or `reference/`.
+- Summarize recurring lessons into stable docs instead of carrying forward a lightly edited archive of old reflections.

--- a/skills/llmdoc-update/SKILL.md
+++ b/skills/llmdoc-update/SKILL.md
@@ -20,6 +20,7 @@ Before editing stable docs:
 - read `llmdoc/index.md`
 - read `llmdoc/startup.md` and the MUST docs it lists
 - proactively read relevant `llmdoc/guides/` and `llmdoc/memory/reflections/`
+- when recurring lessons have already been promoted into stable docs, prefer those stable docs first and open raw reflections only when the original task context still matters
 - align with the user before non-trivial edits
 
 Then execute this workflow:
@@ -39,6 +40,12 @@ Then execute this workflow:
 4. Update stable llmdoc docs.
    - Update only the impacted docs.
    - Promote lessons into `must/`, `guides/`, or `reference/` only when they are stable and likely to recur.
+   - If `llmdoc/memory/reflections/` now contains more than 5 files, run a consolidation pass before finishing the update.
+   - Consolidate by recurring lesson, not by reflection chronology.
+   - Promote short cross-task rules into `must/`.
+   - Promote reusable constraints, checklists, thresholds, and small worked examples into `reference/`.
+   - Use plain language. Add examples only when they make the lesson easier to apply.
+   - Update an existing stable doc when it already fits the lesson. Do not create a catch-all summary dump and do not copy reflection text verbatim.
    - Split docs aggressively instead of appending to large mixed files.
 
 5. Synchronize `llmdoc/index.md`.

--- a/skills/llmdoc/SKILL.md
+++ b/skills/llmdoc/SKILL.md
@@ -34,6 +34,7 @@ Then load only the specific extras you need:
 
 - Read `llmdoc/index.md`, then `llmdoc/startup.md`, then the MUST files it lists.
 - Proactively read relevant `guides/` and `memory/reflections/` before non-trivial edits.
+- When `llmdoc/memory/reflections/` grows beyond 5 files, use `/llmdoc:update` to consolidate recurring lessons into plain-language `must/` or `reference/` docs instead of letting memory keep growing unchecked.
 - The main assistant, not `worker`, aligns with the user before non-trivial edits.
 - At the end of a non-trivial task, the main assistant should consider prompting for `/llmdoc:update`.
 - Temporary investigation artifacts live in `.llmdoc-tmp/`, not `llmdoc/memory/`.

--- a/skills/llmdoc/references/doc-structure.md
+++ b/skills/llmdoc/references/doc-structure.md
@@ -51,6 +51,7 @@ Use this split:
 - One ownership boundary or invariant cluster per architecture doc.
 - Put repeated startup knowledge in `must/`, not in `overview/`.
 - Put mistakes and raw learnings in `memory/reflections/`, then promote only recurring stable lessons.
+- When reflections exceed 5 files, consolidate recurring patterns into plain-language `must/` or `reference/` docs so `memory/` does not become the default retrieval surface.
 - Keep temporary investigation reports in `.llmdoc-tmp/`, not in `llmdoc/memory/`.
 
 ## Recommended architecture slicing

--- a/skills/llmdoc/references/operating-protocol.md
+++ b/skills/llmdoc/references/operating-protocol.md
@@ -10,11 +10,14 @@ If `llmdoc/` exists:
 4. Proactively read task-relevant `guides/` and `memory/reflections/` before planning or editing.
 5. Read the remaining task-relevant docs from `overview/`, `architecture/`, and `reference/`.
 
+When recurring lessons have already been promoted into stable docs, prefer those stable docs first and use raw reflections selectively.
+
 Why:
 
 - startup reads give the minimum common context
 - proactive guide reads reduce avoidable implementation mistakes
 - proactive reflection reads reduce repeated workflow mistakes
+- promoted stable docs keep reflection history from becoming the default retrieval surface
 
 ## Re-entry rules
 

--- a/skills/llmdoc/references/templates.md
+++ b/skills/llmdoc/references/templates.md
@@ -25,7 +25,7 @@
 ## Routing Rules
 - Read `startup.md` for startup context
 - Read `guides/` before editing a known workflow
-- Read `memory/reflections/` before repeating a workflow or revisiting a problematic subsystem
+- Read the relevant stable docs first, then `memory/reflections/` selectively when you need the original task context for a repeated workflow or problematic subsystem
 ```
 
 ## `startup.md`
@@ -44,7 +44,7 @@ Escalate to more docs when:
 - changing architecture or conventions
 - updating workflows or stable docs
 
-Read related guides and reflections before editing when available.
+Read related guides and the relevant stable docs or reflections before editing when available.
 ```
 
 ## `overview/project-overview.md`

--- a/skills/llmdoc/references/update-and-memory.md
+++ b/skills/llmdoc/references/update-and-memory.md
@@ -18,6 +18,8 @@ Why reflection comes first:
 - missing-doc signals are easier to capture before they are rationalized away
 - stable docs should absorb only durable lessons, not raw frustration
 
+Reflections are process memory, not the final long-term rule surface.
+
 ## End-of-task update prompt
 
 At the end of a non-trivial task, the main assistant should actively evaluate whether the user should be prompted to run `/llmdoc:update`.
@@ -46,6 +48,34 @@ Read relevant reflections:
 - before repeating a workflow that previously failed
 - before updating docs after a difficult or ambiguous task
 - after user corrections, failed tests, or major rework
+
+When recurring lessons have already been promoted into stable docs, prefer those stable docs first and re-open raw reflections only when the original task context still matters.
+
+## Reflection consolidation
+
+`llmdoc/memory/reflections/` should not grow into a second documentation system.
+
+When the directory grows beyond 5 reflection files, the next `/llmdoc:update` should run a consolidation pass:
+
+- group reflections by recurring lesson, not by date or filename
+- extract reusable rules, constraints, and reminders instead of retelling each task
+- write the stable version in plain language
+- use a short example only when it makes the lesson easier to apply
+- update an existing stable doc when it already has the right home
+- avoid creating a catch-all "reflection summary" file
+- do not copy or lightly paraphrase reflection text into stable docs
+
+Default destinations:
+
+- `must/`: short cross-task rules that should matter on nearly every run
+- `reference/`: reusable constraints, checklists, thresholds, lookup facts, and worked examples
+
+Examples:
+
+- If several reflections all point to "align with the user before non-trivial edits", promote one short `must/` rule instead of preserving the lesson only as repeated memory.
+- If multiple reflections expose the same update checklist, promote one `reference/` note that states the checklist clearly and adds a short example of when to use it.
+
+After consolidation, future retrieval should prefer the resulting stable docs and use raw reflections selectively.
 
 ## Memory ownership
 


### PR DESCRIPTION
Updated documentation to clarify the use of the `llmdoc` skill before code exploration and non-trivial edits. Added guidance on consolidating reflections into stable documents when the reflection count exceeds five, ensuring that recurring lessons are captured effectively. Introduced a new guide on consolidating reflections to prevent memory overload and improve retrieval efficiency.

Changes applied across multiple files including AGENTS, README, and llmdoc references.